### PR TITLE
Viewport Fit Cover + Font Family Fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en"><head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width">
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 	<meta name="color-scheme" content="dark light">
 	<meta name="robots" content="all">
 	<meta name="theme-color" content="black">

--- a/style.css
+++ b/style.css
@@ -1,4 +1,9 @@
 :root {
+	--safe-area-inset-left: env(safe-area-inset-left, 0px);
+	--safe-area-inset-right: env(safe-area-inset-right, 0px);
+	--safe-area-inset-top: env(safe-area-inset-top, 0px);
+	--safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+
 	--transparent-background: #0003;
 	--transparent-background-no-backdrop-filter: #111c;
 	--shadow-color: #0004;
@@ -26,7 +31,7 @@
 
 body {
 	margin: 0;
-	font-family: system-ui;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", system-ui, sans-serif;
 	box-sizing: border-box;
 
 	position: fixed;
@@ -44,7 +49,8 @@ body {
 }
 
 main {
-	padding-block: 1rem;
+	--padding-block: 1rem;
+	padding: max(var(--safe-area-inset-top), var(--padding-block)) var(--safe-area-inset-right) max(var(--safe-area-inset-bottom), var(--padding-block)) var(--safe-area-inset-left);
 	display: flex;
 	flex-direction: column;
 	gap: 2rem;
@@ -163,9 +169,12 @@ main {
 }
 
 .projects h2 {
-	padding: .5rem .8rem;
+	--padding-inline: .8rem;
+	padding: .5rem var(--padding-inline);
+	padding-left: calc(var(--padding-inline) + var(--safe-area-inset-left));
 	inline-size: fit-content;
 	border-radius: 0 1rem 1rem 0;
+	transform: translateX(calc(var(--safe-area-inset-left) * -1));
 }
 
 .projects ul {


### PR DESCRIPTION
I really like the design of your website! Thought it would look nice with fullscreen support for devices with camera cutouts, like modern iPhones and the like.

### Viewport Fit: Default
![Screenshot of Viewport Fit Default](https://user-images.githubusercontent.com/65947371/162845637-7e2744c3-881e-4081-865f-04f3edd6a438.PNG)

### Viewport Fit: Cover
![Screenshot of Viewport Fit Cover](https://user-images.githubusercontent.com/65947371/162845733-8da52517-e14a-42ac-817e-0c89e1fb69c7.PNG)

Here's a list of the things I changed in the commit:

Additions:
- Added fullscreen support for devices that take advantage of the Safe Area Inset environment variables in CSS. This allows the body's background image to take up all of the space on the screen, where available. This is enabled from within the viewport meta tag, which then allows the page layout to be fully managed from CSS after that.
- Added a few fallbacks to the body's font family declaration. I noticed that system-ui wasn't working on Chrome OS, and I believe Firefox still doesn't have support for it yet. These additional fallbacks will allow the system font to appear correctly for more devices and browsers that don't yet support system-ui.